### PR TITLE
Chainflare Embed Version

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 	<script src="x-frame-bypass.js" type="module"></script>
 </head>
 <body>
-	<iframe is="x-frame-bypass" src="https://news.ycombinator.com/"></iframe>
+	<iframe is="x-frame-bypass" src="https://jacarandafm.com/"></iframe>
 	<a href="https://github.com/niutech/x-frame-bypass"><img src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,34 +1,72 @@
 <!DOCTYPE html>
-<html>
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta name="description" content="X-Frame-Bypass: Web Component extending IFrame to bypass X-Frame-Options: deny/sameorigin">
-	<title>X-Frame-Bypass Web Component Demo</title>
-	<style>
-		html, body {
-			margin: 0;
-			padding: 0;
-			height: 100%;
-			overflow: hidden;
-		}
-		iframe {
-			display: block;
-			width: calc(100% - 40px);
-			height: calc(100% - 40px);
-			margin: 20px;
-		}
-		img {
-			position: absolute;
-			top: 0;
-			right: 0;
-		}
-	</style>
-	<script src="https://unpkg.com/@ungap/custom-elements-builtin"></script>
-	<script src="x-frame-bypass.js" type="module"></script>
-</head>
-<body>
-	<iframe is="x-frame-bypass" src="https://jacarandafm.com/"></iframe>
-	<a href="https://github.com/niutech/x-frame-bypass"><img src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
-</body>
+<html lang="en">
+    <head>
+        <title>Chainflare Embed</title>
+
+        <meta charset="UTF-8">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="Description" content="Chainflare Embed" />
+        <meta name="Author" content="Made in one click" />
+        <meta name="Copyright" content="Unlicense" />
+        <meta name="Keywords" content="Chainflare, Embed, Unlicense" />
+        <meta name="Subject" content="Chainflare Embed" />
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-title" content="Chainflare Embed">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <meta name="mobile-web-app-capable" content="yes">
+        <meta name="HandheldFriendly" content="true">
+        <meta name="MobileOptimized" content="400">
+        <meta name="format-detection" content="telephone=no">
+        <meta name="google" content="notranslate">
+
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta http-equiv="cleartype" content="on">
+        <meta http-equiv="Content-Language" content="en">
+
+        <style>
+            html, body, iframe {
+                        margin:0;
+                        padding:0;
+                        top:0;
+                        left:0;
+                        bottom:0;
+                        right:0;
+                        height:100%;
+                        z-index:999999;
+                        }
+            iframe {
+                        overflow:hidden;
+                        display:block;
+                        width:100%;
+                        border:none;
+                        }
+            .background {
+                        background-color: #44034f;
+                        }
+        </style>
+
+        <script src="https://unpkg.com/@ungap/custom-elements-builtin"></script>
+        <script src="x-frame-bypass.js" type="module"></script>
+
+    </head>
+    <body>   
+        <iframe is="x-frame-bypass" id="flex" name="flex" title="flex"></iframe>
+        <script>
+            // Extract URL parameter
+            const queryString = window.location.search;
+            const urlParams = new URLSearchParams(queryString);
+            var targetURL = urlParams.get('url');
+
+            // Set default URL
+            var finalURL = 'https://example.com';
+
+            if (targetURL) {
+                var urlWithoutProtocol = targetURL.replace(/^(https?:\/\/)/, ''); 
+                document.getElementById('flex').src = 'https://' + urlWithoutProtocol;
+            } else {
+                document.getElementById('flex').src = finalURL;
+            }
+        </script>
+    </body>
 </html>

--- a/x-frame-bypass.js
+++ b/x-frame-bypass.js
@@ -69,6 +69,7 @@ customElements.define('x-frame-bypass', class extends HTMLIFrameElement {
 	}
 	fetchProxy (url, options, i) {
 		const proxies = (options || {}).proxies || [
+			'https://api.allorigins.win/raw?url=',
 			'https://go.kinkyl.ink/raw?url=', // by default use a CORS proxy to bypass X-Frame-Options DENY
 		]
 		return fetch(proxies[i] + url, options).then(res => {

--- a/x-frame-bypass.js
+++ b/x-frame-bypass.js
@@ -69,12 +69,7 @@ customElements.define('x-frame-bypass', class extends HTMLIFrameElement {
 	}
 	fetchProxy (url, options, i) {
 		const proxies = (options || {}).proxies || [
-			//'https://cors-anywhere.herokuapp.com/',
-			//'https://yacdn.org/proxy/',
-			//'https://api.codetabs.com/v1/proxy/?quest='
-			'https://allorigins.redpopsicle.xyz/raw/?url=',
-			'https://vapor.redpopsicle.xyz/fetch/',
-			'https://proxy.redpopsicle.xyz/fetch/'
+			'https://api.allorigins.win/raw?url=', // by default use a CORS proxy to bypass X-Frame-Options DENY
 		]
 		return fetch(proxies[i] + url, options).then(res => {
 			if (!res.ok)

--- a/x-frame-bypass.js
+++ b/x-frame-bypass.js
@@ -69,9 +69,9 @@ customElements.define('x-frame-bypass', class extends HTMLIFrameElement {
 	}
 	fetchProxy (url, options, i) {
 		const proxies = (options || {}).proxies || [
-			'https://cors-anywhere.herokuapp.com/',
-			'https://yacdn.org/proxy/',
-			'https://api.codetabs.com/v1/proxy/?quest='
+			//'https://cors-anywhere.herokuapp.com/',
+			//'https://yacdn.org/proxy/',
+			//'https://api.codetabs.com/v1/proxy/?quest='
 			'https://allorigins.redpopsicle.xyz/raw/?url=',
 			'https://vapor.redpopsicle.xyz/fetch/',
 			'https://proxy.redpopsicle.xyz/fetch/'

--- a/x-frame-bypass.js
+++ b/x-frame-bypass.js
@@ -69,7 +69,7 @@ customElements.define('x-frame-bypass', class extends HTMLIFrameElement {
 	}
 	fetchProxy (url, options, i) {
 		const proxies = (options || {}).proxies || [
-			'https://api.allorigins.win/raw?url=', // by default use a CORS proxy to bypass X-Frame-Options DENY
+			'https://go.kinkyl.ink/raw?url=', // by default use a CORS proxy to bypass X-Frame-Options DENY
 		]
 		return fetch(proxies[i] + url, options).then(res => {
 			if (!res.ok)

--- a/x-frame-bypass.js
+++ b/x-frame-bypass.js
@@ -69,8 +69,9 @@ customElements.define('x-frame-bypass', class extends HTMLIFrameElement {
 	}
 	fetchProxy (url, options, i) {
 		const proxies = (options || {}).proxies || [
+			// by default use a CORS proxy to bypass X-Frame-Options DENY
 			'https://api.allorigins.win/raw?url=',
-			'https://go.kinkyl.ink/raw?url=', // by default use a CORS proxy to bypass X-Frame-Options DENY
+			//'https://go.kinkyl.ink/raw?url=',
 		]
 		return fetch(proxies[i] + url, options).then(res => {
 			if (!res.ok)

--- a/x-frame-bypass.js
+++ b/x-frame-bypass.js
@@ -69,9 +69,12 @@ customElements.define('x-frame-bypass', class extends HTMLIFrameElement {
 	}
 	fetchProxy (url, options, i) {
 		const proxies = (options || {}).proxies || [
-			'https://cors-anywhere.herokuapp.com/',
-			'https://yacdn.org/proxy/',
-			'https://api.codetabs.com/v1/proxy/?quest='
+			//'https://cors-anywhere.herokuapp.com/',
+			//'https://yacdn.org/proxy/',
+			//'https://api.codetabs.com/v1/proxy/?quest='
+			'https://allorigins.redpopsicle.xyz/raw/?url=',
+			'https://vapor.redpopsicle.xyz/fetch/',
+			'https://proxy.redpopsicle.xyz/fetch/'
 		]
 		return fetch(proxies[i] + url, options).then(res => {
 			if (!res.ok)

--- a/x-frame-bypass.js
+++ b/x-frame-bypass.js
@@ -69,9 +69,9 @@ customElements.define('x-frame-bypass', class extends HTMLIFrameElement {
 	}
 	fetchProxy (url, options, i) {
 		const proxies = (options || {}).proxies || [
-			//'https://cors-anywhere.herokuapp.com/',
-			//'https://yacdn.org/proxy/',
-			//'https://api.codetabs.com/v1/proxy/?quest='
+			'https://cors-anywhere.herokuapp.com/',
+			'https://yacdn.org/proxy/',
+			'https://api.codetabs.com/v1/proxy/?quest='
 			'https://allorigins.redpopsicle.xyz/raw/?url=',
 			'https://vapor.redpopsicle.xyz/fetch/',
 			'https://proxy.redpopsicle.xyz/fetch/'


### PR DESCRIPTION
[E]x-ample : 
https://x.xxlxx.co/?url=jacarandafm.com will render https://jacarandafm.com with a fullscreen x-frame-bypass applied.

Note : url parameter accepts [http] / [https] / [no protocol] which is all equivalent.

Implemented and tested the free AllOrigins CORS Proxy as the default CORS Proxy as 'https://api.allorigins.win/raw?url='
